### PR TITLE
Compilation fixes

### DIFF
--- a/mapping.py
+++ b/mapping.py
@@ -18,19 +18,18 @@ class GroupManager(Base):
 	isadmin = Column(Boolean, nullable=False)
 	email = Column(String, nullable=False)
 	password = Column(String, nullable=False)
-	group_id = Column(Integer, ForeignKey('group.id'))
 
 class Group(Base):
 	__tablename__ = 'group'
  
 	id = Column(Integer, primary_key=True)
 	intro = Column(String, nullable=False)
-	cityid = Column(Integer, nullable=False)
-	managerid = Column(Integer, nullable=False)
+	cityid = Column(Integer, ForeignKey('city.id'), nullable=False)
+	city = relationship('City', backref='group')
+	managerid = Column(Integer, ForeignKey('groupmanager.id'), nullable=False)
 	enabled = Column(Boolean, default=True)
-	city = relationship("City", uselist=False, back_populates="group")
 	groupmanager = relationship("GroupManager", backref="group")
-	events = relationship("Event")
+	events = relationship("Event", backref="group")
 
 class City(Base):
 	__tablename__ = 'city'
@@ -38,18 +37,14 @@ class City(Base):
 	id = Column(Integer, primary_key=True)
 	name = Column(String, nullable=False)
 	timezonename = Column(String, nullable=False)
-	#is character(2) the same as String(2)?
-	countryid = Column(String(2), nullable=False)
-	country_id = Column(Integer, ForeignKey('country.id'))
-	group_id = Column(Integer, ForeignKey('group.id'))
-	group = relationship("Group", backref="city")
+	countryid = Column(String(2), ForeignKey('country.isocode'), nullable=False)
+	country = relationship('Country', backref='city')
 
 class Country(Base):
 	__tablename__ = 'country'
 
 	isocode = Column(String(2), nullable=False, primary_key=True)
 	name = Column(String, nullable= False)
-	cities = relationship("City", backref="country")
 
 class Event(Base):
 	__tablename__ = 'event'

--- a/mapping.py
+++ b/mapping.py
@@ -1,6 +1,6 @@
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import Column, Integer, String, Boolean, MetaData, ForeignKey
+from sqlalchemy import Column, Integer, String, Boolean, MetaData, ForeignKey, DateTime, Float
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm import relationship
 
@@ -19,11 +19,6 @@ class GroupManager(Base):
 	email = Column(String, nullable=False)
 	password = Column(String, nullable=False)
 	group_id = Column(Integer, ForeignKey('group.id'))
-	group = relationship("Group", back_populates="groupmanager")
-
-for gm in session.query(GroupManager).filter(GroupManager.realname.like('%John%')):
-	print gm.realname
-
 
 class Group(Base):
 	__tablename__ = 'group'
@@ -34,7 +29,7 @@ class Group(Base):
 	managerid = Column(Integer, nullable=False)
 	enabled = Column(Boolean, default=True)
 	city = relationship("City", uselist=False, back_populates="group")
-	groupmanager = relationship("GroupManager", uselist=False, back_populates="group")
+	groupmanager = relationship("GroupManager", backref="group")
 	events = relationship("Event")
 
 class City(Base):
@@ -47,14 +42,14 @@ class City(Base):
 	countryid = Column(String(2), nullable=False)
 	country_id = Column(Integer, ForeignKey('country.id'))
 	group_id = Column(Integer, ForeignKey('group.id'))
-	group = relationship("Group", back_populates="city")
+	group = relationship("Group", backref="city")
 
 class Country(Base):
 	__tablename__ = 'country'
 
 	isocode = Column(String(2), nullable=False, primary_key=True)
 	name = Column(String, nullable= False)
-	cities = relationship("City")
+	cities = relationship("City", backref="country")
 
 class Event(Base):
 	__tablename__ = 'event'
@@ -70,3 +65,9 @@ class Event(Base):
 	longitude = Column(Float, nullable=False, default=0)
 	latitude = Column(Float, nullable=False, default=0)
 	group_id = Column(Integer, ForeignKey('group.id'))
+
+
+for gm in session.query(GroupManager).filter(GroupManager.realname.like('%John%')):
+	print gm.realname
+
+

--- a/mapping.py
+++ b/mapping.py
@@ -52,7 +52,7 @@ class City(Base):
 class Country(Base):
 	__tablename__ = 'country'
 
-	isocode = Column(String(2), nullable=False)
+	isocode = Column(String(2), nullable=False, primary_key=True)
 	name = Column(String, nullable= False)
 	cities = relationship("City")
 


### PR DESCRIPTION
This series of patches allows the simple sample query to execute.
- backref should be preferred over back_populates because backref creates object methods in both directions (back_populates operates in only one direction)
- add required ForeignKey references
- add missing relationships
- move sample query to the end

The backtrace involving a missing reference occurred because the class definitions were following the sample query, so they were not yet declared or available when the ORM was attempting to execute the query. Ordering of declarations within the file is indeed important, though that's not immediately clear.
